### PR TITLE
Fix crate unable to be unpacked

### DIFF
--- a/CTLD.lua
+++ b/CTLD.lua
@@ -76,7 +76,7 @@ ctld.buildTimeFOB = 60 --time in seconds for the FOB to be built
 
 ctld.crateWaitTime = 5 -- time in seconds to wait before you can spawn another crate
 
-ctld.forceCrateToBeMoved = true -- a crate must be picked up at least once and moved before it can be unpacked. Helps to reduce crate spam
+ctld.forceCrateToBeMoved = false -- a crate must be picked up at least once and moved before it can be unpacked. Helps to reduce crate spam
 
 ctld.radioSound = "beacon.ogg" -- the name of the sound file to use for the FOB radio beacons. If this isnt added to the mission BEACONS WONT WORK!
 ctld.radioSoundFC3 = "beaconsilent.ogg" -- name of the second silent radio file, used so FC3 aircraft dont hear ALL the beacon noises... :)


### PR DESCRIPTION
### Issue

Slung crates can no longer be unpacked. This is due to the forceCrateToBeMoved variable being set to true. I have reason to believe it is only to be used in conjunction with simulated loading (where everything is internal).

![20201028204834_1](https://user-images.githubusercontent.com/5242169/97423036-c656d180-1962-11eb-84e6-cffc0d6a5494.jpg)

Image shows crate a player 9 miles from base still unable to be unpacked.

### What I did

Reverted the variable back to false.

### How to test

If set to true no matter how far you sling the crate it cannot be unpacked. Internal crates however can be unpacked. This is due to when the internal crate is loaded onto the aircraft the crate is removed from the ctld.crateMove array.

If set to false sling crates as per normal and they will be able to be unpacked.
